### PR TITLE
OLOGIC/OUTFF: OUTFF_Q => OQ

### DIFF
--- a/artix7/site_type_OLOGICE3.json
+++ b/artix7/site_type_OLOGICE3.json
@@ -65,7 +65,7 @@
           },
           "Q": {
             "dir": "OUTPUT",
-            "wire": "OUTFF_Q"
+            "wire": "OQ"
           }
         }
       },
@@ -644,7 +644,7 @@
           },
           "Q": {
             "dir": "OUTPUT",
-            "wire": "OUTFF_Q"
+            "wire": "OQ"
           }
         }
       },

--- a/kintex7/site_type_OLOGICE2.json
+++ b/kintex7/site_type_OLOGICE2.json
@@ -65,7 +65,7 @@
           },
           "Q": {
             "dir": "OUTPUT",
-            "wire": "OUTFF_Q"
+            "wire": "OQ"
           }
         }
       },

--- a/kintex7/site_type_OLOGICE3.json
+++ b/kintex7/site_type_OLOGICE3.json
@@ -65,7 +65,7 @@
           },
           "Q": {
             "dir": "OUTPUT",
-            "wire": "OUTFF_Q"
+            "wire": "OQ"
           }
         }
       },
@@ -644,7 +644,7 @@
           },
           "Q": {
             "dir": "OUTPUT",
-            "wire": "OUTFF_Q"
+            "wire": "OQ"
           }
         }
       },

--- a/zynq7/site_type_OLOGICE3.json
+++ b/zynq7/site_type_OLOGICE3.json
@@ -65,7 +65,7 @@
           },
           "Q": {
             "dir": "OUTPUT",
-            "wire": "OUTFF_Q"
+            "wire": "OQ"
           }
         }
       },
@@ -644,7 +644,7 @@
           },
           "Q": {
             "dir": "OUTPUT",
-            "wire": "OUTFF_Q"
+            "wire": "OQ"
           }
         }
       },


### PR DESCRIPTION
Since prjxray has no notion of site internals, 
set the OUTFF output wire identical to the site output wire to implement ODDR,
in order to be able to route the ODDR output.